### PR TITLE
Fix login form: add missing method=post

### DIFF
--- a/login.php
+++ b/login.php
@@ -24,7 +24,7 @@
 					<img src="logo-nav-2.png" class="mx-auto" alt="...">
 				</div>
 				<h5 class="card-title text-center mb-5">aMule Web</h5>
-				<form name="login">
+				<form action="" method="post" name="login">
 			   			<input name="pass" type="password" class="form-control mb-3" placeholder="Password" required autofocus>
 						<div class="d-grid gap-2">
 			   				<button class="btn btn-secondary" type="submit" name="submit" value="Submit">Login</button>


### PR DESCRIPTION
## Bug
Login on the adaptable template silently fails — page just reloads,
no error shown. Default template login works fine.

## Cause
The login <form> has no action/method attribute, so the browser
defaults to GET. amuleweb only processes login as POST, so the
request is never handled as a login attempt.

## Fix
Add action="" method="post" to the form, matching the default
template's behavior.

## Tested
Confirmed via manual curl POST replicating the form submit, verified
against amuled logs.